### PR TITLE
removed setTimeout in popupjs file without causing html el detection errors

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -4,28 +4,26 @@ import {
   saveToBlocklist,
 } from "./helpers/runtimeApi";
 
-setTimeout(() => {
-  let checkbox = document.getElementById("blockbox");
+let checkbox = document.getElementById("blockbox");
 
-  checkbox.addEventListener("change", (e) => {
-    getCurrentTab((link) => {
-      saveToBlocklist({
-        link,
-        isBlocklisted: e.target.checked,
-      });
+checkbox.addEventListener("change", (e) => {
+  getCurrentTab((link) => {
+    saveToBlocklist({
+      link,
+      isBlocklisted: e.target.checked,
     });
   });
+});
 
-  getBlocklist((res) => {
-    let blocklistArray;
-    blocklistArray = res;
+getBlocklist((res) => {
+  let blocklistArray;
+  blocklistArray = res;
 
-    getCurrentTab((link) => {
-      let hostname = new URL(link).hostname;
-      blocklistArray.forEach((item, index) => {
-        item.name === hostname &&
-          (checkbox.checked = blocklistArray[index].isBlocklisted);
-      });
+  getCurrentTab((link) => {
+    let hostname = new URL(link).hostname;
+    blocklistArray.forEach((item, index) => {
+      item.name === hostname &&
+        (checkbox.checked = blocklistArray[index].isBlocklisted);
     });
   });
-}, 200);
+});

--- a/src/popup.html
+++ b/src/popup.html
@@ -4,8 +4,6 @@
     <link rel="stylesheet" href="./css/popup.css" />
   </head>
   <body>
-    <script src="./js/popup.bundle.js"></script>
-
     <div class="setting-container">
       <div>
         <p>Disable on this site</p>
@@ -17,5 +15,6 @@
         </label>
       </div>
     </div>
+    <script src="./js/popup.bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
In the _popup.html_ placed the _popup.js_ script file at the end of the _body_ element so that js file can see the rest of the elements that previously were before it. The toggle animation still takes time and visibly toggles when popup is opened.